### PR TITLE
Added in missing input parameter

### DIFF
--- a/node/action.yml
+++ b/node/action.yml
@@ -11,8 +11,8 @@ outputs:
   results:
     description: Any found vulnerability results
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: 'docker'
+  image: 'Dockerfile'
 branding:
-  icon: "shield"
-  color: "purple"
+  icon: 'shield'
+  color: 'purple'

--- a/node/action.yml
+++ b/node/action.yml
@@ -4,12 +4,15 @@ inputs:
   ignore:
     description: Provide list of vulnerabilities to ignore
     required: false
+  options:
+    description: Additional options flags pass to the snyk cli (see https://support.snyk.io/hc/en-us/articles/360003812578-Our-full-CLI-reference)
+    required: false
 outputs:
   results:
     description: Any found vulnerability results
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
 branding:
-  icon: 'shield'
-  color: 'purple'
+  icon: "shield"
+  color: "purple"


### PR DESCRIPTION
The action was throwing warnings when passing an option to the node. I believe it's because the action.yml has a missing option.

Cheers,
Andy