### PR TITLE
Use latest npm

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM snyk/snyk-cli:1.263.0-npm
+FROM snyk/snyk-cli:npm
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Node 18 and the version of snyk installed is not compatible, using the latest version of snyk npm allowed the use of node18