### PR TITLE
feat: allow scanning dependencies specified in poetry projects

### DIFF
--- a/python/action.yml
+++ b/python/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: The package file to scan for dependencies
     required: false
     default: requirements.txt
+  lockFile:
+    description: If using poetry, the poetry lockfile used to specify exact dependency versions
+    required: false
   ignore:
     description: Provide list of vulnerabilities to ignore
     required: false


### PR DESCRIPTION
With this change if the action is invoked as before, there is no difference. Alternatively the inputs can now include `lockFile`, e.g.:

```yaml
        ...
         uses: konsentus/action.snyk/node@v4.1.0
        with:
          lockFile: poetry.lock
```

This will skip installing the dependencies explicitly and instead verify the `pyproject.toml` and `poetry.lock`  dependencies via poetry.

Note even though the `pyproject.toml` is not mentioned explicitly, if this file cannot be found the action will fail. Furthermore if the `lockFile` appears out-of-sync with the `pyproject.toml` this action will also fail